### PR TITLE
Upgrade to newest version of level dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
   },
   "homepage": "https://github.com/thlorenz/level-dump",
   "dependencies": {
-    "level": "~0.18.0",
+    "level": "~1.7.0",
     "minimist": "~1.1.1"
   },
   "devDependencies": {
-    "level-sublevel": "~6.4.6",
-    "level-test": "~1.7.0",
+    "level-sublevel": "~6.6.1",
+    "level-test": "~2.0.3",
     "tap": "~0.4.3",
     "tape": "~1.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "level-dump",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "Dumps all values and/or keys of a level db or a sublevel to the console.",
   "main": "level-dump.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "level-dump",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Dumps all values and/or keys of a level db or a sublevel to the console.",
   "main": "level-dump.js",
   "bin": {


### PR DESCRIPTION
Fixes #4 - `npm install` fails on some newer versions of node.  Tested by `npm install`ing successfully, and then `npm run test`.

I also bumped the minor version, but let me know if you'd prefer to do that yourself when you publish it.